### PR TITLE
Support connection to a multi node cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ Check [this section](https://github.com/hseeberger/constructr#coordination) in C
 
 Check [reference.conf](constructr-coordination-zookeeper/src/main/resources/reference.conf) for ZooKeeper related configuration.
 
+### Configuring ZK cluster nodes ###
+
+The default configuration tries to establish a connection to ZooKeeper on `localhost:2181`.
+
+Override the `constructr.coordination.nodes` configuration to specify another ZooKeeper node:
+
+```
+constructr.coordination.nodes = ["10.10.10.10:2181"]
+```
+
+The format per node `ip:port`.
+
+You are also able to connect to a multi-node cluster by specifying multiple nodes, separated by a comma:
+
+```
+constructr.coordination.nodes = ["10.10.10.10:2181", "10.10.10.11:2181", "10.10.10.12:2181"]
+```
+
 ## Testing
 
 Requirements:

--- a/constructr-coordination-zookeeper/src/main/resources/reference.conf
+++ b/constructr-coordination-zookeeper/src/main/resources/reference.conf
@@ -15,8 +15,7 @@
 constructr {
   coordination {
     class-name       = com.lightbend.constructr.coordination.zookeeper.ZookeeperCoordination
-    host             = localhost
-    port             = 2181
+    nodes            = ["localhost:2181"]
     connection-delay = 1 second
     connection-retry = 3
   }


### PR DESCRIPTION
The `constructr.coordination.host` and `constructr.coordination.port` configuration keys have been replaced by the `constructr.coordination.nodes` key. This allows to declare multiple ZK nodes to establish a connection to a multi-node cluster.