### PR TITLE
Disable retries

### DIFF
--- a/constructr-coordination-zookeeper/src/main/resources/reference.conf
+++ b/constructr-coordination-zookeeper/src/main/resources/reference.conf
@@ -16,7 +16,5 @@ constructr {
   coordination {
     class-name       = com.lightbend.constructr.coordination.zookeeper.ZookeeperCoordination
     nodes            = ["localhost:2181"]
-    connection-delay = 1 second
-    connection-retry = 3
   }
 }


### PR DESCRIPTION
The retry mechanism offered by the curator zookeeper client is not used because Constructr itself implements a retry mechanism already.