### PR TITLE
Cross release Scala 2.11 and 2.12 on maven

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,6 @@ object Build extends AutoPlugin {
 
     // Release settings
     releaseCrossBuild := true,
-    releasePublishArtifactsAction := publishSigned.value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,
@@ -66,7 +65,7 @@ object Build extends AutoPlugin {
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
-      ReleaseStep(action = Command.process("publishSigned", _)),
+      ReleaseStep(action = Command.process("+publishSigned", _)),
       setNextVersion,
       commitNextVersion,
       ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),


### PR DESCRIPTION
The build settings have been fixed so that `sbt-release` releases both the Scala 2.11 and 2.12 artifacts to maven.