### PR TITLE
Update curator dependency version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Version {
   val akka             = "2.4.17"
   val constructr       = "0.16.1"
-  val curator          = "2.11.0"
+  val curator          = "2.12.0"
   val scala211         = "2.11.8"
   val scala212         = "2.12.1"
   val scalaTest        = "3.0.1"


### PR DESCRIPTION
Update the version of Curator from 2.11.0 to 2.12.0.

Solves a problem with the Guava dependency of Curator clashing with newer versions of Guava.

See this pull request on curator for more info: https://github.com/apache/curator/pull/204