### PR TITLE
Turn zookeeper nodes to EPHEMERAL ones

### DIFF
--- a/constructr-coordination-zookeeper/src/main/scala/com/lightbend/constructr/coordination/zookeeper/ZookeeperCoordination.scala
+++ b/constructr-coordination-zookeeper/src/main/scala/com/lightbend/constructr/coordination/zookeeper/ZookeeperCoordination.scala
@@ -22,7 +22,7 @@ import java.time.Instant
 import java.util.Base64
 
 import akka.Done
-import akka.actor.{ActorSystem, Address, AddressFromURIString}
+import akka.actor.{ ActorSystem, Address, AddressFromURIString }
 import de.heikoseeberger.constructr.coordination.Coordination
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex
@@ -33,7 +33,7 @@ import org.apache.zookeeper.KeeperException.NodeExistsException
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.concurrent.{Future, blocking}
+import scala.concurrent.{ Future, blocking }
 
 private object ZookeeperCoordination {
 
@@ -74,18 +74,18 @@ private object ZookeeperCoordination {
 }
 
 /**
-  * A coordination service for ConstructR that uses Zookeeper as the distributed data store.
-  *
-  * The locking mechanism is using the [[InterProcessSemaphoreMutex]] lock from the Apache Curator library
-  * in combination with an additional lock file to store the TTL.
-  *
-  * Zookeeper does not support the concept that keys can expiry based on a TTL.
-  * Therefore, this implementation is using [[Instant]] to represent a TTL.
-  * The instant value is stored inside the key as a data object.
-  * It is stored in Zookeeper as milliseconds, converted to a byte array and then encoded as a Base64 string.
-  * The TTL in milliseconds represents the time elapsed since 1970-01-01T00:00:00 UTC.
-  * Because TTL value is always converted into the UTC time zone, it can be safely used across different time zones.
-  */
+ * A coordination service for ConstructR that uses Zookeeper as the distributed data store.
+ *
+ * The locking mechanism is using the [[InterProcessSemaphoreMutex]] lock from the Apache Curator library
+ * in combination with an additional lock file to store the TTL.
+ *
+ * Zookeeper does not support the concept that keys can expiry based on a TTL.
+ * Therefore, this implementation is using [[Instant]] to represent a TTL.
+ * The instant value is stored inside the key as a data object.
+ * It is stored in Zookeeper as milliseconds, converted to a byte array and then encoded as a Base64 string.
+ * The TTL in milliseconds represents the time elapsed since 1970-01-01T00:00:00 UTC.
+ * Because TTL value is always converted into the UTC time zone, it can be safely used across different time zones.
+ */
 final class ZookeeperCoordination(clusterName: String, system: ActorSystem) extends Coordination with ZookeeperNodes {
 
   import ZookeeperCoordination.Converters._


### PR DESCRIPTION
This is in response to #30.
This has been tested on Zookeeper 3.4.9