### PR TITLE
Fix +test being broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,10 @@ sudo: required
 
 language: scala
 
-scala:
-  - 2.12.3
-  - 2.11.11
-
 jdk:
   - oraclejdk8
 
 services:
   - docker
 
-script: sbt test
+script: sbt run-tests

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -40,6 +40,7 @@ object Build extends AutoPlugin {
     unmanagedSourceDirectories.in(Compile) := Vector(scalaSource.in(Compile).value),
     unmanagedSourceDirectories.in(Test) := Vector(scalaSource.in(Test).value),
 
+
     // Scalariform settings
     SbtScalariform.autoImport.scalariformPreferences := SbtScalariform.autoImport.scalariformPreferences.value
       .setPreference(AlignSingleLineCaseStatements, true)
@@ -61,7 +62,7 @@ object Build extends AutoPlugin {
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
-      runTest,
+      releaseStepCommand("run-tests"),
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
@@ -71,5 +72,9 @@ object Build extends AutoPlugin {
       ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
       pushChanges
     )
-  )
+
+    // FIXME
+    // For some reason, +test results in tests failing due to bincompat issues, explicitly
+    // issuing clean seems to work around it for now
+  ) ++ addCommandAlias("run-tests", s";++${Version.scala211};clean;test;++${Version.scala212};clean;test")
 }


### PR DESCRIPTION
Perhaps temporary fix, issuing `clean` in between `test` invocations for Scala 2.11 and 2.12 allows it to run successfully. Not sure where the issue lies but I'd like to get a release done so this works for now.